### PR TITLE
PoC: implement core::panic::panic_error

### DIFF
--- a/compiler/rustc_hir/src/lang_items.rs
+++ b/compiler/rustc_hir/src/lang_items.rs
@@ -292,6 +292,7 @@ language_item_table! {
     // a weak lang item, but do not have it defined.
     Panic,                   sym::panic,               panic_fn,                   Target::Fn,             GenericRequirement::Exact(0);
     PanicFmt,                sym::panic_fmt,           panic_fmt,                  Target::Fn,             GenericRequirement::None;
+    PanicError,              sym::panic_error,         panic_error,                Target::Fn,             GenericRequirement::None;
     PanicDisplay,            sym::panic_display,       panic_display,              Target::Fn,             GenericRequirement::None;
     PanicStr,                sym::panic_str,           panic_str,                  Target::Fn,             GenericRequirement::None;
     ConstPanicFmt,           sym::const_panic_fmt,     const_panic_fmt,            Target::Fn,             GenericRequirement::None;

--- a/compiler/rustc_span/src/symbol.rs
+++ b/compiler/rustc_span/src/symbol.rs
@@ -959,6 +959,7 @@ symbols! {
         panic_abort,
         panic_bounds_check,
         panic_display,
+        panic_error,
         panic_fmt,
         panic_handler,
         panic_impl,

--- a/library/core/src/panic.rs
+++ b/library/core/src/panic.rs
@@ -58,6 +58,19 @@ pub macro panic_2021 {
     ),
 }
 
+/// Panic the current thread with the given error as the panic payload.
+///
+/// The message can be of any (`Error + 'static`) type, not just strings.
+///
+/// See the [`panic!`] macro for more information about panicking.
+#[unstable(feature = "panic_error", issue = "none")]
+#[inline]
+#[track_caller]
+#[cfg(not(bootstrap))]
+pub fn panic_error<E: 'static + crate::error::Error>(error: E) -> ! {
+    crate::panicking::panic_error(&error);
+}
+
 /// An internal trait used by libstd to pass data from libstd to `panic_unwind`
 /// and other panic runtimes. Not intended to be stabilized any time soon, do
 /// not use.

--- a/library/core/src/panic/panic_info.rs
+++ b/library/core/src/panic/panic_info.rs
@@ -1,6 +1,8 @@
 use crate::any::Any;
 use crate::fmt;
 use crate::panic::Location;
+#[cfg(not(bootstrap))]
+use crate::error::Error;
 
 /// A struct providing information about a panic.
 ///
@@ -28,9 +30,27 @@ use crate::panic::Location;
 #[stable(feature = "panic_hooks", since = "1.10.0")]
 #[derive(Debug)]
 pub struct PanicInfo<'a> {
-    payload: &'a (dyn Any + Send),
+    payload: PayloadKind<'a>,
     message: Option<&'a fmt::Arguments<'a>>,
     location: &'a Location<'a>,
+}
+
+#[derive(Debug)]
+enum PayloadKind<'a> {
+    Any(&'a (dyn Any + Send)),
+    #[cfg(not(bootstrap))]
+    Error(&'a (dyn Error + 'static)),
+}
+
+impl<'a> PayloadKind<'a> {
+    fn downcast_ref<T: 'static>(&self) -> Option<&T> {
+        match self {
+            PayloadKind::Any(payload) => payload.downcast_ref(),
+            #[cfg(not(bootstrap))]
+            PayloadKind::Error(_) => None,
+            // PayloadKind::Error(error) => error.downcast_ref(),
+        }
+    }
 }
 
 impl<'a> PanicInfo<'a> {
@@ -46,7 +66,23 @@ impl<'a> PanicInfo<'a> {
         location: &'a Location<'a>,
     ) -> Self {
         struct NoPayload;
-        PanicInfo { location, message, payload: &NoPayload }
+        PanicInfo { location, message, payload: PayloadKind::Any(&NoPayload) }
+    }
+
+    #[unstable(
+        feature = "panic_internals",
+        reason = "internal details of the implementation of the `panic!` and related macros",
+        issue = "none"
+    )]
+    #[doc(hidden)]
+    #[inline]
+    #[cfg(not(bootstrap))]
+    pub fn error_constructor(
+        // message: Option<&'a fmt::Arguments<'a>>,
+        error: &'a (dyn crate::error::Error + 'static),
+        location: &'a Location<'a>,
+    ) -> Self {
+        PanicInfo { location, message: None, payload: PayloadKind::Error(error) }
     }
 
     #[unstable(
@@ -57,7 +93,7 @@ impl<'a> PanicInfo<'a> {
     #[doc(hidden)]
     #[inline]
     pub fn set_payload(&mut self, info: &'a (dyn Any + Send)) {
-        self.payload = info;
+        self.payload = PayloadKind::Any(info);
     }
 
     /// Returns the payload associated with the panic.
@@ -84,7 +120,13 @@ impl<'a> PanicInfo<'a> {
     #[must_use]
     #[stable(feature = "panic_hooks", since = "1.10.0")]
     pub fn payload(&self) -> &(dyn Any + Send) {
-        self.payload
+        #[cfg(not(bootstrap))]
+        struct HackerVoice;
+        match self.payload {
+            PayloadKind::Any(payload) => payload,
+            #[cfg(not(bootstrap))]
+            PayloadKind::Error(_) => &HackerVoice, // I'm in
+        }
     }
 
     /// If the `panic!` macro from the `core` crate (not from `std`)
@@ -94,6 +136,17 @@ impl<'a> PanicInfo<'a> {
     #[unstable(feature = "panic_info_message", issue = "66745")]
     pub fn message(&self) -> Option<&fmt::Arguments<'_>> {
         self.message
+    }
+
+    /// If the panic was created with `panic_error` returns the source error of the panic.
+    #[must_use]
+    #[unstable(feature = "panic_error", issue = "none")]
+    #[cfg(not(bootstrap))]
+    pub fn error(&self) -> Option<&(dyn core::error::Error + 'static)> {
+        match self.payload {
+            PayloadKind::Any(_) => None,
+            PayloadKind::Error(source) => Some(source),
+        }
     }
 
     /// Returns information about the location from which the panic originated,

--- a/library/std/src/lib.rs
+++ b/library/std/src/lib.rs
@@ -311,6 +311,7 @@
 #![feature(nll)]
 #![feature(nonnull_slice_from_raw_parts)]
 #![feature(once_cell)]
+#![cfg_attr(not(bootstrap), feature(panic_error))]
 #![feature(panic_info_message)]
 #![feature(panic_internals)]
 #![feature(panic_unwind)]

--- a/src/test/ui/panics/panic-error.rs
+++ b/src/test/ui/panics/panic-error.rs
@@ -1,0 +1,33 @@
+// run-pass
+#![feature(panic_error)]
+
+use std::panic::PanicInfo;
+use std::fmt;
+
+fn install_panic_hook() {
+    let old_hook = std::panic::take_hook();
+    let new_hook = move |info: &PanicInfo| {
+        old_hook(info);
+        if let Some(source) = info.error() {
+            eprintln!("Error: {}", source);
+        }
+    };
+    std::panic::set_hook(Box::new(new_hook));
+}
+
+fn main() {
+    install_panic_hook();
+    let error = MyError;
+    core::panic::panic_error(error);
+}
+
+#[derive(Debug)]
+struct MyError;
+
+impl core::error::Error for MyError {}
+
+impl fmt::Display for MyError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "my error occurred")
+    }
+}


### PR DESCRIPTION
This is a proof of concept for integrating the new `core::error::Error` trait into the panic runtime. This will eventually evolve into a full proposal and possibly RFC, but for now it is quick and dirty just to test the core concepts and the shape of the API so I can share it with other project members and discuss the design prior to refinement.